### PR TITLE
Improve network visualization and clustering

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -36,12 +36,6 @@
             <label for="filterStress">Stress Tolerance</label>
             <select id="filterStress" multiple></select>
 
-            <label for="filterVegetable">Vegetable</label>
-            <select id="filterVegetable" multiple>
-                <option value="Yes">Yes</option>
-                <option value="No">No</option>
-            </select>
-
             <label for="filterUsage">Usage</label>
             <select id="filterUsage" multiple></select>
 
@@ -93,7 +87,7 @@
                     <input id="clusterK" type="number" value="5" min="2" max="15" step="1" />
                 </div>
                 <div id="clusterChart" class="chart"></div>
-                <div id="networkChart" class="chart"></div>
+                <div id="parallelCatsChart" class="chart"></div>
                 <div id="vegetableChart" class="chart"></div>
             </div>
         </div>


### PR DESCRIPTION
Replace network graph with a Plotly Parallel Categories chart, harden clustering for empty/tiny datasets, and remove the redundant 'Vegetable' filter.

The network graph was replaced with a more visually appealing and informative Parallel Categories chart, which is now wired to a new backend endpoint. Clustering logic was made more robust to handle edge cases with empty or very small datasets, and the UI now provides clear feedback. The 'Vegetable' filter was removed as its functionality is already covered by the 'Usage' filter, simplifying the user interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0a6510d-2464-4dbc-963c-e0d512004e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0a6510d-2464-4dbc-963c-e0d512004e53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

