### PR TITLE
Simplify and visualize pca clustering

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -76,9 +76,9 @@
                 <div id="similarPlants" class="similar-list"></div>
             </div>
 
-            <button id="showAdvanced">Advanced Analytics</button>
-            <div id="advancedAnalytics" style="display:none;">
+            <div id="advancedAnalytics">
                 <div id="clusterChart" class="chart"></div>
+                <div id="clusterSummary" class="summary"></div>
                 <div id="networkChart" class="chart"></div>
                 <div id="vegetableChart" class="chart"></div>
             </div>


### PR DESCRIPTION
Remove all non-PCA clustering, consolidating to a single PCA-based KMeans, and visualize its results in the analytics section.

---
<a href="https://cursor.com/background-agent?bcId=bc-488d1c8b-ce80-481a-922c-5945602521b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-488d1c8b-ce80-481a-922c-5945602521b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

